### PR TITLE
Set App background color to BLACK on Android

### DIFF
--- a/Build/android/java/src/org/zgameeditor/ZgeActivity.java
+++ b/Build/android/java/src/org/zgameeditor/ZgeActivity.java
@@ -29,6 +29,7 @@ import android.app.Activity;
 import android.os.Bundle;
 import android.view.Window;
 import android.view.WindowManager;
+import android.graphics.Color;
 
 public class ZgeActivity extends Activity
 {
@@ -47,6 +48,8 @@ public class ZgeActivity extends Activity
 
         zge = new Zge(this);
         setContentView( zge );
+        
+        getWindow().getDecorView().setBackgroundColor(Color.BLACK);
     }
 
     @Override


### PR DESCRIPTION
On Android, the app background color is white, while on PC it is black. This is visible when ZGE project App.ClearColor is not set (=transparent).
With this fix, both will have a black background.