### PR TITLE
Add batch scripts to compile Android 32 and 64 libraries

### DIFF
--- a/Build/makeAndroid32.bat
+++ b/Build/makeAndroid32.bat
@@ -1,0 +1,12 @@
+pushd "%~dp0"
+
+if not exist "android\java\libs\armeabi-v7a\" mkdir android\java\libs\armeabi-v7a
+if not exist "android\lib\arm-linux\" mkdir android\lib\arm-linux
+
+PATH=C:\Android\android-ndk-r21e\toolchains\arm-linux-androideabi-4.9\prebuilt\windows-x86_64\bin;
+
+CD android
+C:\FPC\trunk\bin\i386-win32\ppcrossarm -B -MDelphi -Sghi -O3 -Tandroid -Parm -XXis -vw -Filib\arm-linux -FlC:\Android\android-ndk-r21e\platforms\android-29\arch-arm\usr\lib -Fu. -Fu..\.. -FUlib\arm-linux\ -FEjava\libs\armeabi-v7a\ -olibzgeandroid.so -dANDROID -dMINIMAL -Xd -CpARMV6 -CfVFPv2 -FuC:\FPC\trunk\units\arm-android\fcl-base -FuC:\FPC\trunk\units\arm-android\hash -FuC:\FPC\trunk\units\arm-android\rtl-objpas -FuC:\FPC\trunk\units\arm-android\paszlib zgeandroid.pas
+
+popd
+pause

--- a/Build/makeAndroid64.bat
+++ b/Build/makeAndroid64.bat
@@ -1,0 +1,12 @@
+pushd "%~dp0"
+
+if not exist "android\java\libs\arm64-v8a\" mkdir android\java\libs\arm64-v8a
+if not exist "android\lib\arm64-linux\" mkdir android\lib\arm64-linux
+
+PATH=C:\Android\android-ndk-r21e\toolchains\aarch64-linux-android-4.9\prebuilt\windows-x86_64\bin;
+
+CD android
+C:\FPC\trunk\bin\i386-win32\ppcrossa64 -B -MDelphi -Sghi -O3 -Tandroid -Paarch64 -XXis -vw -Filib\arm64-linux -FlC:\Android\android-ndk-r21e\platforms\android-29\arch-arm64\usr\lib -Fu. -Fu..\.. -FUlib\arm64-linux\ -FEjava\libs\arm64-v8a\ -olibzgeandroid.so -dANDROID -dMINIMAL -Xd -CpARMV8 -FuC:\FPC\trunk\units\aarch64-android\fcl-base -FuC:\FPC\trunk\units\aarch64-android\hash -FuC:\FPC\trunk\units\aarch64-android\rtl-objpas -FuC:\FPC\trunk\units\aarch64-android\paszlib zgeandroid.pas
+
+popd
+pause


### PR DESCRIPTION
Add batch scripts to compile Android 32 and 64 libzgeandroid.so libraries from Windows.

Side note:
To follow Android official nomenclature, libzgeandroid.so 32-bit is created in `armeabi-v7a` folder, instead of `armeabi` folder.