### PR TITLE
Update Zge.java

### DIFF
--- a/tools/ZDesigner/exe/Android/Template/4.1/src/org/zgameeditor/Zge.java
+++ b/tools/ZDesigner/exe/Android/Template/4.1/src/org/zgameeditor/Zge.java
@@ -78,7 +78,7 @@ public class Zge extends GLSurfaceView
         System.loadLibrary("zgeandroid");
 
         String dataPath = context.getFilesDir().getAbsolutePath() + "/";
-        String libraryPath = getContext().getApplicationInfo().dataDir + "/lib/";
+        String libraryPath = getContext().getApplicationInfo().nativeLibraryDir + "/";
         String extPath = Environment.getExternalStorageDirectory().getAbsolutePath();
         NativeInit(extPath, dataPath, libraryPath);
 


### PR DESCRIPTION
getContext().getApplicationInfo().dataDir + "/lib/" replaced by getContext().getApplicationInfo().nativeLibraryDir + "/" to get the correct path to the lib for Android 64.
Works for Android 32 too.
There is no need to import android.content.pm.ApplicationInfo;