### PR TITLE
Update ZPlatform_Android.inc

### DIFF
--- a/ZPlatform_Android.inc
+++ b/ZPlatform_Android.inc
@@ -781,7 +781,7 @@ begin
   RunClass := Env^.FindClass(Env, 'java/lang/Runtime');
 
   Mid := Env^.GetStaticMethodID(Env, RunClass , 'getRuntime', '()Ljava/lang/Runtime;');
-  RunObj := Env^.CallStaticObjectMethodV(Env, RunClass, Mid, nil);
+  RunObj := Env^.CallStaticObjectMethod(Env, RunClass, Mid);
 
   Mid := Env^.GetMethodID(Env, RunClass , 'availableProcessors', '()I');
   Result := Env^.CallIntMethod(Env,RunObj,Mid);


### PR DESCRIPTION
Suppression of the last parameter nil in the call to Env^.CallStaticObjectMethodV to repair threads on Android 64 bits