### PR TITLE
Update ZPlatform_Android.inc

### DIFF
--- a/ZPlatform_Android.inc
+++ b/ZPlatform_Android.inc
@@ -730,7 +730,7 @@ begin
 end;
 
 {$IFDEF CPU64}
-function ThreadWrapper(Data : pointer) : Int64; stdcall;
+function ThreadWrapper(Data : pointer) : Int64;
 {$ELSE}
 function ThreadWrapper(Data : pointer) : longint;
 {$ENDIF}


### PR DESCRIPTION
Not sure if stdcall; is needed. It was hinted by the compilation error which told me to replace longint by Int64, but maybe it isn't needed.