### PR TITLE
Correct allocation size for Android mutex

### DIFF
--- a/ZPlatform_Android.inc
+++ b/ZPlatform_Android.inc
@@ -547,7 +547,7 @@ function Platform_CreateMutex : pointer;
 var
   P : PRTLCriticalSection;
 begin
-  P := GetMem(SizeOf(Pointer));
+  P := GetMem(SizeOf(TRTLCriticalSection));
   InitCriticalSection(P^);
   Result := P;
 end;


### PR DESCRIPTION
Allocated incorrect size (SizeOf(Pointer)) for TRTLCriticalSection, causing heap corruption. Changed to use SizeOf(TRTLCriticalSection).