### PR TITLE
Use of project filename instead of title for run.bat

### DIFF
--- a/tools/ZDesigner/frmEditor.pas
+++ b/tools/ZDesigner/frmEditor.pas
@@ -5365,7 +5365,7 @@ begin
       Lookups.Add('$keystorealias$', Self.AndroidKeystoreAlias );
     end;
 
-    ApkFileName := ProjectPath + 'bin\' + String(Self.ZApp.Caption);
+    ApkFileName := ProjectPath + 'bin\' + ChangeFileExt(ExtractFileName(CurrentFileName), '');
     if IsDebug then
       ApkFileName := ApkFileName + '-debug.apk'
     else


### PR DESCRIPTION
Changed String(Self.ZApp.Caption) by ChangeFileExt(ExtractFileName(CurrentFileName), '') to obtain the correct $apkpath$ that is used in the generated run.bat when building APK (debug).